### PR TITLE
1.0.4 final version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disvas",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Simple package based on Discord image manipulation to suit your needs!",
   "main": "index.js",
   "types": "typings/index.d.ts",


### PR DESCRIPTION
No version is due after 1.0.4
(1.0.3 is skipped)

Tag: Final

Final version of Disvas. This PR confirms that any more version after 1.0.4 is forbidden.